### PR TITLE
Remove embedded ObjectMetadata from LicenseFile

### DIFF
--- a/api/licensing/license.go
+++ b/api/licensing/license.go
@@ -36,7 +36,7 @@ type LicenseFile struct {
 	Signature []byte `json:"signature"`
 
 	// ObjectMeta contains the name, namespace, labels and annotations
-	corev2.ObjectMeta `json:"metadata"`
+	ObjectMeta corev2.ObjectMeta `json:"metadata"`
 }
 
 // GetObjectMeta returns empty metadata because only a single license is

--- a/api/licensing/license_validator_test.go
+++ b/api/licensing/license_validator_test.go
@@ -114,8 +114,8 @@ func testMockLicenseFile() *LicenseFile {
 // Test that serializing and deserializing a license produces the same object.
 func TestLicenseDeserialization(t *testing.T) {
 	file := licenseFile(licensePayload())
-	file.Labels = nil
-	file.Annotations = nil
+	file.ObjectMeta.Labels = nil
+	file.ObjectMeta.Annotations = nil
 	encodedFile, err := json.Marshal(file)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Currently the embedded ObjectMetadata struct causes our store wrapping logic to treat the license as protobuf serializable.

This is a pretty lame problem that I've ran into before, so we should probably rethink the idea of how we're wrapping/unwrapping resources. This gets us past the issue for now.

Signed-off-by: Christian Kruse <ctkruse99@gmail.com>